### PR TITLE
small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,14 @@ to use a different directory you may need to modify the scripts to suit.
 	tar zxvf huawei-hg612-munin-1.0.tgz
 
 4. A cron job must be set up to run every 5 minutes and the user running the
-plugin must be able to write to /etc/munin/huawei/output.txt:
-	*/5 * * * * /etc/munin/huawei/getstats.sh
+plugin must be able to write to `/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt`.
+
+	cp /etc/munin/huawei/crontab /etc/cron.d/huawei-hg612-munin
 
 5. If you wish to enable any of the plugins, create a symlink for each one in
 the munin plugins directory.  Or, copy and paste the following:
 
-	cd /etc/munin/plugins
-	ln -s /etc/munin/huawei/plugins/hg612_attenuation
-	ln -s /etc/munin/huawei/plugins/hg612_current_speed
-	ln -s /etc/munin/huawei/plugins/hg612_errors
-	ln -s /etc/munin/huawei/plugins/hg612_max_speed
-	ln -s /etc/munin/huawei/plugins/hg612_ptm1
-	ln -s /etc/munin/huawei/plugins/hg612_ptm1_uptime
-	ln -s /etc/munin/huawei/plugins/hg612_pwr
-	ln -s /etc/munin/huawei/plugins/hg612_snr
-	ln -s /etc/munin/huawei/plugins/hg612_sync_speed
+	ln -s /etc/munin/huawei/plugins/hg612_* /etc/munin/plugins
 
 6. The huawei.expect script is configured to connect to 192.168.1.1 and use 
 the default username and password.  If this isn't what you want, simply modify

--- a/crontab
+++ b/crontab
@@ -1,0 +1,1 @@
+*/5 * * * *	munin	/etc/munin/plugins/huawei-hg612-munin/getstats.sh

--- a/getstats.sh
+++ b/getstats.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-expect /etc/munin/huawei/huawei.expect  | tee | tr -d "\015"  > /etc/munin/huawei/output.txt
+
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+
+expect `dirname $0`/huawei.expect  | tee | tr -d "\015"  > $statsfile

--- a/plugins/hg612_attenuation
+++ b/plugins/hg612_attenuation
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_current_speed
+++ b/plugins/hg612_current_speed
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_errors
+++ b/plugins/hg612_errors
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_interleaving
+++ b/plugins/hg612_interleaving
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_max_speed
+++ b/plugins/hg612_max_speed
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_ptm1
+++ b/plugins/hg612_ptm1
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_ptm1_uptime
+++ b/plugins/hg612_ptm1_uptime
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_pwr
+++ b/plugins/hg612_pwr
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_snr
+++ b/plugins/hg612_snr
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 

--- a/plugins/hg612_sync_speed
+++ b/plugins/hg612_sync_speed
@@ -1,7 +1,7 @@
 #!/bin/sh
 # -*- sh -*-
 
-statsfile="/etc/munin/huawei/output.txt"
+statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
 
 : << =cut
 


### PR DESCRIPTION
Set the default to /var/lib/munin/plugin-state/huawei-hg612-munin-output.txt
for safety.

Include a crontab file to be placed in /etc/cron.d.

Update readme to match, and simplify.
