### PR TITLE
Handle recent firmware updates

### DIFF
--- a/plugins/hg612_current_speed
+++ b/plugins/hg612_current_speed
@@ -49,10 +49,10 @@ if [ "$1" = "config" ]; then
 fi;
 
 echo -n "downstream.value "
-echo $(grep Upstream $statsfile  | grep Path  | head -n 1 | awk '{ print $11 }')000
+echo $(grep Upstream $statsfile  | grep 'Path\|Bearer'  | head -n 1 | awk '{ print $11 }')000
 
 echo -n "upstream.value "
-echo $(grep Upstream $statsfile  | grep Path  | head -n 1 | awk '{ print $6 }')000
+echo $(grep Upstream $statsfile  | grep 'Path\|Bearer'  | head -n 1 | awk '{ print $6 }')000
 
 	exit 0
 fi

--- a/plugins/hg612_sync_speed
+++ b/plugins/hg612_sync_speed
@@ -59,13 +59,13 @@ echo -n "maxdownstream.value "
 echo $(grep Upstream $statsfile  | grep Max  | head -n 1 | awk '{ print $10 }')000
 
 echo -n "downstream.value "
-echo $(grep Upstream $statsfile  | grep Path  | head -n 1 | awk '{ print $11 }')000
+echo $(grep Upstream $statsfile  | grep 'Path\|Bearer'  | head -n 1 | awk '{ print $11 }')000
 
 echo -n "maxupstream.value "
 echo $(grep Upstream $statsfile  | grep Max  | head -n 1 | awk '{ print $5 }')000
 
 echo -n "upstream.value "
-echo $(grep Upstream $statsfile  | grep Path  | head -n 1 | awk '{ print $6 }')000
+echo $(grep Upstream $statsfile  | grep 'Path\|Bearer'  | head -n 1 | awk '{ print $6 }')000
 
 
 	exit 0


### PR DESCRIPTION
OpenReach have kindly updated the firmware on the HG612.

The current sync speed text has changed to 'Bearer', so we look
for that now, as well as 'Path'.
