### PR TITLE
Add the host_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,26 @@
-This is a collection of munin plugins for monitoring various details of the Huawei
-HG612 device.  The HG612 is installed by OpenReach for certain types of DSL connections.
-It is normally installed in a locked-down state but can be unlocked to provide
-additional information and configuration -- just search "HG612 Hacking" and you
-will find all of the information you need.
+## HG612 plugins for Munin
 
-These scripts are provided for the free use of anyone who wishes to use them.
-They were written by me for my own personal use, and as such may or may not need
-to be modified to suit your purposes.
+This is a collection of munin plugins for monitoring various details of the Huawei HG612 device.  The HG612 is installed by OpenReach for certain types of DSL connections (mostly FTTC "Infinity" and LLU installations).
 
-My code is not perfect but does the job for me, and may need to be modified for
-you.  Improvements are welcome.
+Most Openreach installations are in a locked-down state but can be unlocked to provide additional information and configuration -- just search "HG612 Hacking" and you will find all of the information you need.
 
-I've provided some instructions to add these into munin -- they will only show
-up as a new graph section (hg612) for an existing host (if you require them to show up
-as a separate host in munin, please reconfigure to suit.)
 
-HOW TO USE:
+### Installation
 
-1. This code was written to be run with Munin on a Linux host.  It requires an
-unlocked HG612 and for the "expect" scripting language to be installed.
+- Install ```netcat``` and ```expect```
+- Download and unpack the repository into ```/etc/munin/huawei```
+- Install the crontab, either manually in the ```munin``` user for your system, or ```cp crontab /etc/cron.d/huawei-hg612-munin```
+- Symlink the required plugins into ```/etc/munin/plugins``` using ```ln -s /etc/munin/huawei/plugins/hg612_* /etc/munin/plugins/```
+- Modify ```/etc/munin/huawei/getstats.sh``` for your modem's IP, username, and password.
+- Add an host entry for ```hg612``` to your ```munin.conf``` file
 
-2. This script was configured to be run from /etc/munin/huawei and if you need
-to use a different directory you may need to modify the scripts to suit.
+### License
 
-3. To extract:
-	cd /etc/munin
-	tar zxvf huawei-hg612-munin-1.0.tgz
+These files are distributed under the GPL v3, please see the included ```LICENSE``` file for further details. 
 
-4. A cron job must be set up to run every 5 minutes and the user running the
-plugin must be able to write to `/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt`.
+### Authors
 
-	cp /etc/munin/huawei/crontab /etc/cron.d/huawei-hg612-munin
-
-5. If you wish to enable any of the plugins, create a symlink for each one in
-the munin plugins directory.  Or, copy and paste the following:
-
-	ln -s /etc/munin/huawei/plugins/hg612_* /etc/munin/plugins
-
-6. The huawei.expect script is configured to connect to 192.168.1.1 and use 
-the default username and password.  If this isn't what you want, simply modify
-the expect script.
-
+- [bugmancx](https://github.com/bugmancx) - Original Author
+- [Chris Williams](https://github.com/bingos)
+- [Andrew Williams](https://github.com/nikdoof)
+- [Chris Wilson](https://github.com/qris)

--- a/README.md
+++ b/README.md
@@ -8,15 +8,24 @@ Most Openreach installations are in a locked-down state but can be unlocked to p
 ### Installation
 
 - Install ```netcat``` and ```expect```
-- Download and unpack the repository into ```/etc/munin/huawei```
+- Download and unpack the repository into ```/etc/munin/huawei-hg612-munin/```
 - Install the crontab, either manually in the ```munin``` user for your system, or ```cp crontab /etc/cron.d/huawei-hg612-munin```
 - Symlink the required plugins into ```/etc/munin/plugins``` using ```ln -s /etc/munin/huawei-hg612-munin/plugins/hg612_* /etc/munin/plugins/```
-- Modify ```/etc/munin/huawei-hg612-munin/getstats.sh``` for your modem's IP
-- Add an host entry for ```hg612``` to your ```munin.conf``` file
+- Set  your modem's IP by renaming ```config.sample``` as ```config```, then editi it.
+- Add an host entry for ```hg612``` in your ```munin.conf``` file, ie:  
+
+    ```
+    [hg612]
+    	address	127.0.0.1
+    ```
+     _(replace 127.0.0.1 with the ip address of the munin-node hosting this hg612 plugins)_
+- Restart your munin-node , ie: ```/etc/init.d/munin-node restart```
+
 
 ### License
 
 These files are distributed under the GPL v3, please see the included ```LICENSE``` file for further details. 
+
 
 ### Authors
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Most Openreach installations are in a locked-down state but can be unlocked to p
 - Download and unpack the repository into ```/etc/munin/huawei```
 - Install the crontab, either manually in the ```munin``` user for your system, or ```cp crontab /etc/cron.d/huawei-hg612-munin```
 - Symlink the required plugins into ```/etc/munin/plugins``` using ```ln -s /etc/munin/huawei-hg612-munin/plugins/hg612_* /etc/munin/plugins/```
-- Modify ```/etc/munin/huawei-hg612-munin/getstats.sh``` for your modem's IP, username, and password.
+- Modify ```/etc/munin/huawei-hg612-munin/getstats.sh``` for your modem's IP
 - Add an host entry for ```hg612``` to your ```munin.conf``` file
 
 ### License

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Most Openreach installations are in a locked-down state but can be unlocked to p
 - Install ```netcat``` and ```expect```
 - Download and unpack the repository into ```/etc/munin/huawei```
 - Install the crontab, either manually in the ```munin``` user for your system, or ```cp crontab /etc/cron.d/huawei-hg612-munin```
-- Symlink the required plugins into ```/etc/munin/plugins``` using ```ln -s /etc/munin/huawei/plugins/hg612_* /etc/munin/plugins/```
-- Modify ```/etc/munin/huawei/getstats.sh``` for your modem's IP, username, and password.
+- Symlink the required plugins into ```/etc/munin/plugins``` using ```ln -s /etc/munin/huawei-hg612-munin/plugins/hg612_* /etc/munin/plugins/```
+- Modify ```/etc/munin/huawei-hg612-munin/getstats.sh``` for your modem's IP, username, and password.
 - Add an host entry for ```hg612``` to your ```munin.conf``` file
 
 ### License

--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ These files are distributed under the GPL v3, please see the included ```LICENSE
 - [Chris Williams](https://github.com/bingos)
 - [Andrew Williams](https://github.com/nikdoof)
 - [Chris Wilson](https://github.com/qris)
+- [Soif](https://github.com/soif)

--- a/plugins/hg612_attenuation
+++ b/plugins/hg612_attenuation
@@ -37,6 +37,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+		echo "host_name hg612"
         echo "graph_title Line Attenuation (dB)"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Line Attenuation (dB)'

--- a/plugins/hg612_attenuation
+++ b/plugins/hg612_attenuation
@@ -39,10 +39,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category line'
         echo "graph_title Line Attenuation (dB)"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Line Attenuation (dB)'
-        echo 'graph_category hg612'
         echo 'graph_scale no'
 
 # There are seven VDSL bands to monitor, so we want to get the band names

--- a/plugins/hg612_attenuation
+++ b/plugins/hg612_attenuation
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -37,7 +38,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-		echo "host_name hg612"
+        echo "host_name $host_name"
         echo "graph_title Line Attenuation (dB)"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Line Attenuation (dB)'

--- a/plugins/hg612_current_speed
+++ b/plugins/hg612_current_speed
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo "graph_title Sync Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Speed (bps)'

--- a/plugins/hg612_current_speed
+++ b/plugins/hg612_current_speed
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo "graph_title Sync Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Speed (bps)'

--- a/plugins/hg612_current_speed
+++ b/plugins/hg612_current_speed
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category speed'
         echo "graph_title Sync Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Speed (bps)'
-        echo 'graph_category hg612'
         echo 'graph_scale yes'
         echo 'graph_order downstream upstream'
         echo 'downstream.label Downstream'

--- a/plugins/hg612_errors
+++ b/plugins/hg612_errors
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+	echo "host_name hg612"
 	echo "graph_title Errors"
 	echo "graph_args --base 1000"
 	echo 'graph_vlabel errors down (-) / up (+) per ${graph_period}'

--- a/plugins/hg612_errors
+++ b/plugins/hg612_errors
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
     echo "host_name $host_name"
+	echo "graph_category line"
 	echo "graph_title Errors"
 	echo "graph_args --base 1000"
 	echo 'graph_vlabel errors down (-) / up (+) per ${graph_period}'
-	echo "graph_category hg612"
 	echo "graph_scale no"
 
 

--- a/plugins/hg612_errors
+++ b/plugins/hg612_errors
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	echo "host_name hg612"
+    echo "host_name $host_name"
 	echo "graph_title Errors"
 	echo "graph_args --base 1000"
 	echo 'graph_vlabel errors down (-) / up (+) per ${graph_period}'

--- a/plugins/hg612_interleaving
+++ b/plugins/hg612_interleaving
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo 'graph_title Interleave Depth'
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Interleave Depth'

--- a/plugins/hg612_interleaving
+++ b/plugins/hg612_interleaving
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category line'
         echo 'graph_title Interleave Depth'
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Interleave Depth'
-        echo 'graph_category hg612'
         echo 'graph_scale no'
         echo 'graph_order upstream downstream'
         echo 'downstream.label Downstream'

--- a/plugins/hg612_interleaving
+++ b/plugins/hg612_interleaving
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo 'graph_title Interleave Depth'
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Interleave Depth'

--- a/plugins/hg612_max_speed
+++ b/plugins/hg612_max_speed
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo "graph_title Maximum Attainable Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Max Speed (bps)'

--- a/plugins/hg612_max_speed
+++ b/plugins/hg612_max_speed
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category speed'
         echo "graph_title Maximum Attainable Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Max Speed (bps)'
-        echo 'graph_category hg612'
         echo 'graph_scale yes'
         echo 'graph_order downstream upstream'
         echo 'downstream.label Downstream'

--- a/plugins/hg612_max_speed
+++ b/plugins/hg612_max_speed
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo "graph_title Maximum Attainable Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Max Speed (bps)'

--- a/plugins/hg612_ptm1
+++ b/plugins/hg612_ptm1
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+	echo "host_name hg612"
 	echo "graph_title ptm1 traffic"
 	echo "graph_args --base 1000"
 	echo 'graph_vlabel bytes per ${graph_period}'

--- a/plugins/hg612_ptm1
+++ b/plugins/hg612_ptm1
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
     echo "host_name $host_name"
+	echo "graph_category network"
 	echo "graph_title ptm1 traffic"
 	echo "graph_args --base 1000"
 	echo 'graph_vlabel bytes per ${graph_period}'
-	echo "graph_category hg612"
 	echo "down.label received"
 	echo "down.type DERIVE"
 #	echo "down.graph no"

--- a/plugins/hg612_ptm1
+++ b/plugins/hg612_ptm1
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-	echo "host_name hg612"
+    echo "host_name $host_name"
 	echo "graph_title ptm1 traffic"
 	echo "graph_args --base 1000"
 	echo 'graph_vlabel bytes per ${graph_period}'

--- a/plugins/hg612_ptm1_uptime
+++ b/plugins/hg612_ptm1_uptime
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo "graph_title ptm1 Uptime in days"
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel VDSL Uptime in days'

--- a/plugins/hg612_ptm1_uptime
+++ b/plugins/hg612_ptm1_uptime
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category system'
         echo "graph_title ptm1 Uptime in days"
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel VDSL Uptime in days'
-        echo 'graph_category hg612'
         echo 'graph_scale no'
         echo 'uptime.label Uptime in days'
         echo 'uptime.draw AREA'

--- a/plugins/hg612_ptm1_uptime
+++ b/plugins/hg612_ptm1_uptime
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo "graph_title ptm1 Uptime in days"
         echo 'graph_args --base 1000 -l 0'
         echo 'graph_vlabel VDSL Uptime in days'

--- a/plugins/hg612_pwr
+++ b/plugins/hg612_pwr
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo "graph_title Aggregate Tx Power"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Actual Aggregate Tx Power (dBm)'

--- a/plugins/hg612_pwr
+++ b/plugins/hg612_pwr
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo "graph_title Aggregate Tx Power"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Actual Aggregate Tx Power (dBm)'

--- a/plugins/hg612_pwr
+++ b/plugins/hg612_pwr
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category line'
         echo "graph_title Aggregate Tx Power"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Actual Aggregate Tx Power (dBm)'
-        echo 'graph_category hg612'
         echo 'graph_scale no'
         echo 'downstream.label Downstream'
         echo 'downstream.draw LINE'

--- a/plugins/hg612_snr
+++ b/plugins/hg612_snr
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo 'graph_title SNR Margin (dB)'
         echo 'graph_args --base 1000'
         echo 'graph_vlabel SNR Margin (dB)'

--- a/plugins/hg612_snr
+++ b/plugins/hg612_snr
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo 'graph_title SNR Margin (dB)'
         echo 'graph_args --base 1000'
         echo 'graph_vlabel SNR Margin (dB)'

--- a/plugins/hg612_snr
+++ b/plugins/hg612_snr
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category line'
         echo 'graph_title SNR Margin (dB)'
         echo 'graph_args --base 1000'
         echo 'graph_vlabel SNR Margin (dB)'
-        echo 'graph_category hg612'
         echo 'graph_scale no'
         echo 'graph_order upstream downstream'
         echo 'downstream.label Downstream'

--- a/plugins/hg612_sync_speed
+++ b/plugins/hg612_sync_speed
@@ -35,6 +35,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
+        echo "host_name hg612"
         echo "graph_title Attainable vs Current Sync Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Sync Rate Actual (-) Attainable (+)'

--- a/plugins/hg612_sync_speed
+++ b/plugins/hg612_sync_speed
@@ -2,6 +2,7 @@
 # -*- sh -*-
 
 statsfile=${statsfile:-/var/lib/munin/plugin-state/huawei-hg612-munin-output.txt}
+host_name=${host_name:-"hg612"}
 
 : << =cut
 
@@ -35,7 +36,7 @@ fi
 
 if [ "$1" = "config" ]; then
 
-        echo "host_name hg612"
+        echo "host_name $host_name"
         echo "graph_title Attainable vs Current Sync Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Sync Rate Actual (-) Attainable (+)'

--- a/plugins/hg612_sync_speed
+++ b/plugins/hg612_sync_speed
@@ -37,10 +37,10 @@ fi
 if [ "$1" = "config" ]; then
 
         echo "host_name $host_name"
+        echo 'graph_category speed'
         echo "graph_title Attainable vs Current Sync Speed"
         echo 'graph_args --base 1000'
         echo 'graph_vlabel Sync Rate Actual (-) Attainable (+)'
-        echo 'graph_category hg612'
         echo 'graph_scale yes'
         echo 'downstream.label Downstream'
         echo 'downstream.draw LINE'


### PR DESCRIPTION
Add the host_name value so that the graph are displayed as a separate node.
Then all graphs are splitted in different categories.

The defaut node name is 'hg612', but can be overridden by setting the *env.host_name* in the ```/etc/munin/plugin-conf.d```  configuration file, ie:

```
 [hg612_*]
env.statsfile /var/lib/munin/huawei-hg612-munin-output.txt
env.host_name modem-hg612.local
```

enjoy

BTW some of the commits have been initiated by @nikdoof 🍻 